### PR TITLE
only send context information if user wants it

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -31,7 +31,7 @@ local _on_digiline_receive = function(pos, _, channel, msg)
 
   if msg.command == "get" and msg.item and type(msg.item) == 'string' then
     local result = {
-      request = msg,
+      request = (msg.context and msg) or nil,
       response = digiline_craftdb.craftdb:get_all_recipes(msg.item)
     }
     digilines.receptor_send(pos, digilines.rules.default, channel, result)
@@ -39,7 +39,7 @@ local _on_digiline_receive = function(pos, _, channel, msg)
 
   if msg.command == "find" and msg.item and type(msg.item) == 'string' then
     local result = {
-      request = msg,
+      request = (msg.context and msg) or nil,
       response = digiline_craftdb.craftdb:find_all_matching_items(
         msg.item, msg.offset, msg.max_count)
     }
@@ -94,3 +94,4 @@ minetest.register_craft({
     {"", "digilines:wire_std_00000000", ""},
   },
 })
+


### PR DESCRIPTION
I was going to suggest only sending msg.context back.

User scripts should be aware of what they asked for. If they are multitasking, then they would add something to the request.
```msg.context = { breadcrumbs = { smthsmth }, job = 4 }```

This is a compromise suggestion for your consideration.
maybe there is a better name for the field. It's worth making your mod use less by default than adding overhead to all requests.